### PR TITLE
Fix circular reference by using generic i.o. Json

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -7,9 +7,6 @@ import { promisify } from 'util'
 
 const mkdirAsync = promisify(fs.mkdir)
 
-// https://github.com/microsoft/TypeScript/issues/1897
-export type Json = null | boolean | number | string | Json[] | { [prop: string]: Json }
-
 // Usage: let stub: TypedSinonStub<typeof fs.readFile>
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type TypedSinonStub<A extends (...args: any) => any> = sinon.SinonStub<Parameters<A>, ReturnType<A>>

--- a/src/http/http-common.ts
+++ b/src/http/http-common.ts
@@ -1,7 +1,5 @@
 import http from 'http'
 
-import { Json } from '../common'
-
 export type HttpIncomingMessage = http.IncomingMessage & Required<Pick<http.IncomingMessage, 'method' | 'url'>>
 
 export type HttpRequestListener = (req: HttpIncomingMessage, res: http.ServerResponse) => void
@@ -17,8 +15,8 @@ export interface HttpRequest {
   body: Buffer
 }
 
-export type HttpJsonRequest = Omit<HttpRequest, 'body'> & {
-  body: Json
+export type HttpJsonRequest<T> = Omit<HttpRequest, 'body'> & {
+  body: T
 }
 
 export type HttpTextRequest = Omit<HttpRequest, 'body'> & {

--- a/src/http/http-server-base.ts
+++ b/src/http/http-server-base.ts
@@ -69,7 +69,7 @@ export abstract class HttpServerBase<T extends http.Server | https.Server> {
     })
   }
 
-  public getJsonRequests(): HttpJsonRequest[] {
+  public getJsonRequests<T>(): HttpJsonRequest<T>[] {
     return this.requests.map(req => {
       return { ...req, body: JSON.parse(req.body.toString('utf8')) }
     })

--- a/src/http/web-server.ts
+++ b/src/http/web-server.ts
@@ -63,7 +63,7 @@ export class WebServer {
     return HttpsServer.getDefaultClientCerts()
   }
 
-  public getJsonRequests(): HttpJsonRequest[] {
+  public getJsonRequests<T>(): HttpJsonRequest<T>[] {
     return this.httpServer.getJsonRequests()
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { CommandEmulation, CommandEmulationOptions } from './command-emulation'
-import { createTempDirectory, Json, TypedSinonStub } from './common'
+import { createTempDirectory, TypedSinonStub } from './common'
 import { HttpServer, HttpServerOptions } from './http/http-server'
 import { HttpsServer, HttpsServerOptions } from './http/https-server'
 import { WebServer, WebServerOptions } from './http/web-server'
@@ -11,7 +11,6 @@ export {
   HttpServerOptions,
   HttpsServer,
   HttpsServerOptions,
-  Json,
   TypedSinonStub,
   createTempDirectory,
   WebServer,


### PR DESCRIPTION
Can't build a circular ref:
```
node_modules/@connectedcars/test/build/dist/common.d.ts:2:21 - error TS2456: Type alias 'Json' circularly references itself.

2 export declare type Json = null | boolean | number | string | Json[] | {
                      ~~~~


Found 1 error.
```