### PR TITLE
Named pipe support for QEMU

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "build/dist/src/index.js",
   "types": "build/dist/src/index.d.ts",
   "scripts": {
-    "test": "TZ=UTC jest",
+    "test": "TZ=UTC jest --runInBand",
+    "cov": "TZ=UTC jest --runInBand --coverage=true",
     "build": "npm run build:types && npm run build:js:src",
     "build:js": "npm run build:js:src",
     "build:js:src": "babel src --out-dir ./build/dist/src --extensions '.ts' --source-maps --ignore '**/*.d.ts','src/**/*.test.ts'",
@@ -15,8 +16,7 @@
     "prepare": "npm run build",
     "ci-jest": "TZ=UTC jest --silent --no-color --json 2> /dev/null; res=$?; echo; exit $res",
     "ci-audit": "npm audit --json || true",
-    "ci-eslint": "eslint --format json './src/**/*.{ts,tsx}' || true",
-    "cov": "TZ=UTC jest --coverage=true"
+    "ci-eslint": "eslint --format json './src/**/*.{ts,tsx}' || true"
   },
   "repository": {
     "type": "git",

--- a/src/bin/named-pipe-server.sh
+++ b/src/bin/named-pipe-server.sh
@@ -1,0 +1,23 @@
+# for testing / debugging
+
+pipe=/tmp/testpipe
+
+trap "rm -f $pipe" EXIT
+
+if [[ ! -p $pipe ]]; then
+    mkfifo $pipe
+fi
+
+echo Using $pipe as named pipe
+
+while true
+do
+    if read line <$pipe; then
+        if [[ "$line" == 'exit' ]]; then
+            break
+        fi
+        echo read $line
+    fi
+done
+
+echo "Reader exiting"

--- a/src/bin/named-pipe-server.sh
+++ b/src/bin/named-pipe-server.sh
@@ -1,4 +1,4 @@
-# for testing / debugging
+# for testing / debugging (does not test .in and .out)
 
 pipe=/tmp/testpipe
 

--- a/src/bin/test-exec.sh
+++ b/src/bin/test-exec.sh
@@ -1,0 +1,1 @@
+echo yaboi > /tmp/test-exec.txt

--- a/src/unix/run-process.test.ts
+++ b/src/unix/run-process.test.ts
@@ -230,9 +230,9 @@ describe('run-process', () => {
     it('should run a process which uses named pipes (fifo)', async done => {
       const pipeLocation = '/tmp/testpipe1'
       // Run random command which does not exit. (Is not important we are testing the named pipe functionality)
-      const cmd = new RunProcess('watch', ['echo', 'keepitgoing'], undefined, false, pipeLocation)
+      const cmd = new RunProcess('watch', ['echo', 'keepitgoing'], {}, false, pipeLocation, false)
 
-      await createNamedPipe(pipeLocation)
+      await createNamedPipe(pipeLocation, false)
       await cmd.setupNamedPipeServer()
 
       await cmd.writeToNamedPipe('suttekarl')
@@ -248,9 +248,9 @@ describe('run-process', () => {
     it('should run a process which uses named pipes (fifo), but never find the output', async done => {
       const pipeLocation = '/tmp/testpipe2'
       // Run random command which does not exit. (Is not important we are testing the named pipe functionality)
-      const cmd = new RunProcess('watch', ['echo', 'hello'], undefined, false, '/tmp/testpipe2')
+      const cmd = new RunProcess('watch', ['echo', 'hello'], {}, false, '/tmp/testpipe2')
 
-      await createNamedPipe(pipeLocation)
+      await createNamedPipe(pipeLocation, false)
       await cmd.setupNamedPipeServer()
 
       await cmd.writeToNamedPipe('suttekarl1')

--- a/src/unix/run-process.test.ts
+++ b/src/unix/run-process.test.ts
@@ -210,8 +210,7 @@ describe('run-process', () => {
     it('should run a bash script (which is exec to not create an extra layered sub process)', async done => {
       const endTxtLocation = '/tmp/test-exec.txt'
 
-      //TODO: re-add
-      // expect(fs.existsSync(endTxtLocation)).toEqual(false)
+      expect(fs.existsSync(endTxtLocation)).toEqual(false)
       await new RunProcess('./src/bin/test-exec.sh', [], undefined, true).waitForExit()
       expect(fs.existsSync(endTxtLocation)).toEqual(true)
       fs.unlinkSync(endTxtLocation)
@@ -227,18 +226,11 @@ describe('run-process', () => {
       done()
     }, 5000)
 
+    // Testing with in and out, requires a program that actually does that for us... For debugging change this, and run qemu in the background
     it('should run a process which uses named pipes (fifo)', async done => {
       const pipeLocation = '/tmp/testpipe1'
       // Run random command which does not exit. (Is not important we are testing the named pipe functionality)
-      const cmd = new RunProcess(
-        'watch',
-        ['echo', 'keepitgoing'],
-        // { stdio: 'ignore' } is needed for for the parent process to exit, otherwise it hangs and we get a PIPEWRAP error
-        // { stdio: 'ignore', detached: false },
-        undefined,
-        false,
-        pipeLocation
-      )
+      const cmd = new RunProcess('watch', ['echo', 'keepitgoing'], undefined, false, pipeLocation)
 
       await createNamedPipe(pipeLocation)
       await cmd.setupNamedPipeServer()

--- a/src/unix/run-process.test.ts
+++ b/src/unix/run-process.test.ts
@@ -1,6 +1,9 @@
+import * as fs from 'fs'
+
 import { CommandEmulation } from './command-emulation'
 import { isPidRunning } from './process'
 import {
+  createNamedPipe,
   ProcessNotRunningError,
   RunProcess,
   StandardStreamsStillOpenError,
@@ -8,156 +11,253 @@ import {
 } from './run-process'
 
 describe('run-process', () => {
-  const commandEmulation = new CommandEmulation()
+  describe('spawn processes', () => {
+    const commandEmulation = new CommandEmulation()
 
-  afterAll(async () => {
-    await commandEmulation.cleanup()
-  })
-
-  const processCleanup: Array<RunProcess> = []
-  afterEach(async () => {
-    // Make sure all process are stopped
-    for (const process of processCleanup) {
-      await process.stop()
-    }
-  })
-
-  it('should start a process and wait for exit', async () => {
-    await commandEmulation.registerCommand('my-hello', () => {
-      console.log('hello')
+    afterAll(async () => {
+      await commandEmulation.cleanup()
     })
-    const cmd = new RunProcess('my-hello')
-    processCleanup.push(cmd)
-    const data: Buffer[] = []
-    cmd.stdout?.on('data', chunk => {
-      data.push(chunk)
+
+    const processCleanup: Array<RunProcess> = []
+    afterEach(async () => {
+      // Make sure all process are stopped
+      for (const process of processCleanup) {
+        await process.stop()
+      }
     })
-    await new Promise(resolve => cmd.on('exit', resolve))
-    expect(Buffer.concat(data).toString('utf8')).toEqual('hello\n')
-  })
 
-  it('should start a process and kill it', async () => {
-    await commandEmulation.registerCommand('my-hello', () => {
-      setTimeout(() => {
-        //  Keep node running
-      }, 1000000)
-      console.log('Started...')
-    })
-    const cmd = new RunProcess('my-hello')
-    // Wait for application to start
-    await cmd.waitForOutput(/Started.../)
-
-    // Make sure we don't leak listeners
-    expect(cmd.stdout?.listenerCount('data')).toEqual(0)
-    expect(cmd.stderr?.listenerCount('data')).toEqual(0)
-
-    const res = await cmd.stop()
-    expect(res).toEqual({ code: null, signal: 'SIGTERM' })
-  })
-
-  it('should start a process that ignores SIGTERM and kill it', async () => {
-    await commandEmulation.registerCommand('my-hello', () => {
-      process.on('SIGTERM', () => {
-        // Ignore SIGTERM
+    it('should start a process and wait for exit', async () => {
+      await commandEmulation.registerCommand('my-hello', () => {
+        console.log('hello')
       })
-      setTimeout(() => {
-        console.log('timeout')
-        // Keep node running
-      }, 1000000)
-      console.log('Started...')
-    })
-
-    const cmd = new RunProcess('my-hello')
-    processCleanup.push(cmd)
-
-    // Wait for application to start
-    await cmd.waitForOutput(/Started.../)
-
-    const res = await cmd.stop(10)
-    expect(res).toEqual({ code: null, signal: 'SIGKILL' })
-  })
-
-  it('should start a process and stop it on output', async () => {
-    await commandEmulation.registerCommand('my-hello', () => {
-      setTimeout(() => {
-        console.log('you suck')
-        // Keep node running
-      }, 10)
-    })
-
-    const cmd = new RunProcess('my-hello')
-    processCleanup.push(cmd)
-    cmd.stopOnOutput(/you suck/)
-
-    // Wait for application to start
-    const waiting = cmd.waitForOutput(/Started.../)
-    await expect(waiting).rejects.toThrow(StopBecauseOfOutputError)
-  })
-
-  it(`should start a process that stops when we close it's stdin`, async () => {
-    await commandEmulation.registerCommand('my-hello', () => {
-      setTimeout(() => {
-        // Make sure the process keeps running
-      }, 10000)
-      // Seems we need to listen to the data event before getting the end event
-      process.stdin.on('data', chunk => {
-        process.stdout.write(chunk)
+      const cmd = new RunProcess('my-hello')
+      processCleanup.push(cmd)
+      const data: Buffer[] = []
+      cmd.stdout?.on('data', chunk => {
+        data.push(chunk)
       })
-      process.stdin.on('end', () => {
-        console.log('Stopping...')
+      await new Promise(resolve => cmd.on('exit', resolve))
+      expect(Buffer.concat(data).toString('utf8')).toEqual('hello\n')
+    })
+
+    it('should start a process and kill it', async () => {
+      await commandEmulation.registerCommand('my-hello', () => {
+        setTimeout(() => {
+          //  Keep node running
+        }, 1000000)
+        console.log('Started...')
+      })
+      const cmd = new RunProcess('my-hello')
+      // Wait for application to start
+      await cmd.waitForOutput(/Started.../)
+
+      // Make sure we don't leak listeners
+      expect(cmd.stdout?.listenerCount('data')).toEqual(0)
+      expect(cmd.stderr?.listenerCount('data')).toEqual(0)
+
+      const res = await cmd.stop()
+      expect(res).toEqual({ code: null, signal: 'SIGTERM' })
+    })
+
+    it('should start a process that ignores SIGTERM and kill it', async () => {
+      await commandEmulation.registerCommand('my-hello', () => {
+        process.on('SIGTERM', () => {
+          // Ignore SIGTERM
+        })
+        setTimeout(() => {
+          console.log('timeout')
+          // Keep node running
+        }, 1000000)
+        console.log('Started...')
+      })
+
+      const cmd = new RunProcess('my-hello')
+      processCleanup.push(cmd)
+
+      // Wait for application to start
+      await cmd.waitForOutput(/Started.../)
+
+      const res = await cmd.stop(10)
+      expect(res).toEqual({ code: null, signal: 'SIGKILL' })
+    })
+
+    it('should start a process and stop it on output', async () => {
+      await commandEmulation.registerCommand('my-hello', () => {
+        setTimeout(() => {
+          console.log('you suck')
+          // Keep node running
+        }, 10)
+      })
+
+      const cmd = new RunProcess('my-hello')
+      processCleanup.push(cmd)
+      cmd.stopOnOutput(/you suck/)
+
+      // Wait for application to start
+      const waiting = cmd.waitForOutput(/Started.../)
+      await expect(waiting).rejects.toThrow(StopBecauseOfOutputError)
+    })
+
+    it(`should start a process that stops when we close it's stdin`, async () => {
+      await commandEmulation.registerCommand('my-hello', () => {
+        setTimeout(() => {
+          // Make sure the process keeps running
+        }, 10000)
+        // Seems we need to listen to the data event before getting the end event
+        process.stdin.on('data', chunk => {
+          process.stdout.write(chunk)
+        })
+        process.stdin.on('end', () => {
+          console.log('Stopping...')
+          process.exit(0)
+        })
+        console.log('Started my-hello...')
+      })
+
+      const cmd = new RunProcess('my-hello')
+      processCleanup.push(cmd)
+      const data: Buffer[] = []
+      cmd.stdout?.on('data', chunk => {
+        data.push(chunk)
+      })
+      cmd.stderr?.on('data', chunk => {
+        data.push(chunk)
+      })
+      const matchPromise = cmd.waitForOutput(/Started (.+?)\.\.\./)
+      await expect(matchPromise).resolves.toMatchObject({ 0: 'Started my-hello...', 1: 'my-hello' })
+      cmd.stdin?.end()
+      const exitCodePromise = cmd.waitForExit()
+      await expect(exitCodePromise).resolves.toEqual({ code: 0, signal: null })
+      expect(Buffer.concat(data).toString('utf8')).toEqual('Started my-hello...\nStopping...\n')
+    })
+
+    it(`should repeat when we write to stdin`, async () => {
+      await commandEmulation.registerCommand('my-hello', () => {
+        setTimeout(() => {
+          // Make sure the process keeps running
+        }, 10000)
+        // Seems we need to listen to the data event before getting the end event
+        process.stdin.on('data', chunk => {
+          process.stdout.write(chunk)
+        })
+        process.stdin.on('end', () => {
+          console.log('Stopping...')
+          process.exit(0)
+        })
+        console.log('Started my-hello...')
+      })
+
+      const cmd = new RunProcess('my-hello')
+      processCleanup.push(cmd)
+      const data: Buffer[] = []
+      cmd.stdout?.on('data', chunk => {
+        data.push(chunk)
+      })
+      cmd.stderr?.on('data', chunk => {
+        data.push(chunk)
+      })
+      const matchPromise1 = cmd.waitForOutput(/Started (.+?)\.\.\./)
+      await expect(matchPromise1).resolves.toMatchObject({ 0: 'Started my-hello...', 1: 'my-hello' })
+
+      cmd.stdin?.write('sutte')
+      const matchPromise2 = cmd.waitForOutput(/sutte/)
+      await expect(matchPromise2).resolves.toMatchObject({ 0: 'sutte' })
+
+      cmd.stdin?.end()
+
+      const exitCodePromise = cmd.waitForExit()
+      await expect(exitCodePromise).resolves.toEqual({ code: 0, signal: null })
+      expect(Buffer.concat(data).toString('utf8')).toEqual('Started my-hello...\nsutteStopping...\n')
+    })
+
+    it(`should completely detach process`, async () => {
+      await commandEmulation.registerCommand('my-hello', () => {
+        setTimeout(() => {
+          // Make sure the process keeps running
+        }, 20000)
+      })
+
+      const cmd = new RunProcess('my-hello', [], { detached: true, stdio: ['ignore', 'ignore', 'ignore'] })
+      processCleanup.push(cmd)
+      const exitCodePromise = cmd.waitForExit()
+      await expect(exitCodePromise).resolves.toEqual({ code: 0, signal: null })
+      await expect(isPidRunning(cmd.pid)).resolves.toEqual(true)
+    })
+
+    it(`should detach and fork a new process`, async () => {
+      await commandEmulation.registerCommand('sleeping', () => {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
+        const childProcess = require('child_process')
+        const child = childProcess.spawn('sh', ['-c', 'sleep 0.1; echo hello'], {
+          detached: true,
+          stdio: ['inherit', 'inherit', 'inherit']
+        })
+        child.unref()
         process.exit(0)
       })
-      console.log('Started my-hello...')
+      const cmd = new RunProcess('sleeping', [])
+      await cmd.waitForOutput(/hello/)
+      const stopPromise = cmd.stop()
+      await expect(stopPromise).rejects.toThrow(StandardStreamsStillOpenError)
+      expect(() => {
+        cmd.kill()
+      }).toThrow(ProcessNotRunningError)
     })
-
-    const cmd = new RunProcess('my-hello')
-    processCleanup.push(cmd)
-    const data: Buffer[] = []
-    cmd.stdout?.on('data', chunk => {
-      data.push(chunk)
-    })
-    cmd.stderr?.on('data', chunk => {
-      data.push(chunk)
-    })
-    const matchPromise = cmd.waitForOutput(/Started (.+?)\.\.\./)
-    await expect(matchPromise).resolves.toMatchObject({ 0: 'Started my-hello...', 1: 'my-hello' })
-    cmd.stdin?.end()
-    const exitCodePromise = cmd.waitForExit()
-    await expect(exitCodePromise).resolves.toEqual({ code: 0, signal: null })
-    expect(Buffer.concat(data).toString('utf8')).toEqual('Started my-hello...\nStopping...\n')
   })
 
-  it(`should completely detach process`, async () => {
-    await commandEmulation.registerCommand('my-hello', () => {
-      setTimeout(() => {
-        // Make sure the process keeps running
-      }, 20000)
+  describe('exec processes', () => {
+    it('should be written', () => {
+      expect(true).toEqual(true)
     })
-
-    const cmd = new RunProcess('my-hello', [], { detached: true, stdio: ['ignore', 'ignore', 'ignore'] })
-    processCleanup.push(cmd)
-    const exitCodePromise = cmd.waitForExit()
-    await expect(exitCodePromise).resolves.toEqual({ code: 0, signal: null })
-    await expect(isPidRunning(cmd.pid)).resolves.toEqual(true)
   })
 
-  it(`should detach and fork a new process`, async () => {
-    await commandEmulation.registerCommand('sleeping', () => {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
-      const childProcess = require('child_process')
-      const child = childProcess.spawn('sh', ['-c', 'sleep 0.1; echo hello'], {
-        detached: true,
-        stdio: ['inherit', 'inherit', 'inherit']
+  describe('named pipe', () => {
+    it('should run a process which uses named pipes (fifo)', async () => {
+      const pipeLocation = '/tmp/testpipe1'
+      // Run random command which does not exit. (Is not important we are testing the named pipe functionality)
+      const cmd = new RunProcess('watch', ['echo 85'], { shell: true }, false, pipeLocation)
+
+      await createNamedPipe(pipeLocation)
+      await cmd.setupNamedPipeServer()
+      await cmd.writeToNamedPipe('suttekarl')
+      await cmd.waitForNamedPipeOutput(new RegExp('suttekarl'))
+      // await cmd.stop(0)
+      fs.unlinkSync(pipeLocation)
+      await cmd.stop()
+      expect(cmd.namedPipe?.outDataStr).toEqual('suttekarl\n')
+    }, 12000)
+
+    it.only('fuck lort', async () => {
+      const pipeLocation = '/tmp/testpipe1'
+      // Run random command which does not exit. (Is not important we are testing the named pipe functionality)
+
+      // TODO: any process run which exits manually, (or even not? watch does not exit) gets PIPEWRAP & PROCESSWRAP errors with open handles in jest
+      const cmd = new RunProcess('watch', ['echo', '85']).waitForExit()
+
+      // await createNamedPipe(pipeLocation)
+      // await cmd.setupNamedPipeServer()
+      // await cmd.writeToNamedPipe('suttekarl')
+      // await cmd.waitForNamedPipeOutput(new RegExp('suttekarl'))
+      // await cmd.stop(0)
+      // fs.unlinkSync(pipeLocation)
+      // await cmd.stop()
+      expect(true).toEqual(true)
+    }, 2000)
+
+    it('should run a process which uses named pipes (fifo), but never find the output', async () => {
+      const pipeLocation = '/tmp/testpipe2'
+      // Run random command which does not exit. (Is not important we are testing the named pipe functionality)
+      const cmd = new RunProcess('watch', ['echo hello'], { shell: true }, false, '/tmp/testpipe2')
+
+      await createNamedPipe(pipeLocation)
+      await cmd.setupNamedPipeServer()
+      await cmd.writeToNamedPipe('suttekarl1')
+      await cmd.waitForNamedPipeOutput(new RegExp('suttekarl2'), 500).catch(e => {
+        // Shitty check?
+        expect(e.stack.slice(0, 6)).toEqual('Error:')
       })
-      child.unref()
-      process.exit(0)
-    })
-    const cmd = new RunProcess('sleeping', [])
-    await cmd.waitForOutput(/hello/)
-    const stopPromise = cmd.stop()
-    await expect(stopPromise).rejects.toThrow(StandardStreamsStillOpenError)
-    expect(() => {
-      cmd.kill()
-    }).toThrow(ProcessNotRunningError)
+
+      fs.unlinkSync(pipeLocation)
+    }, 2000)
   })
 })

--- a/src/unix/run-process.test.ts
+++ b/src/unix/run-process.test.ts
@@ -210,7 +210,8 @@ describe('run-process', () => {
     it('should run a bash script (which is exec to not create an extra layered sub process)', async done => {
       const endTxtLocation = '/tmp/test-exec.txt'
 
-      expect(fs.existsSync(endTxtLocation)).toEqual(false)
+      //TODO: re-add
+      // expect(fs.existsSync(endTxtLocation)).toEqual(false)
       await new RunProcess('./src/bin/test-exec.sh', [], undefined, true).waitForExit()
       expect(fs.existsSync(endTxtLocation)).toEqual(true)
       fs.unlinkSync(endTxtLocation)
@@ -233,7 +234,8 @@ describe('run-process', () => {
         'watch',
         ['echo', 'keepitgoing'],
         // { stdio: 'ignore' } is needed for for the parent process to exit, otherwise it hangs and we get a PIPEWRAP error
-        { stdio: 'ignore' },
+        // { stdio: 'ignore', detached: false },
+        undefined,
         false,
         pipeLocation
       )
@@ -254,7 +256,7 @@ describe('run-process', () => {
     it('should run a process which uses named pipes (fifo), but never find the output', async done => {
       const pipeLocation = '/tmp/testpipe2'
       // Run random command which does not exit. (Is not important we are testing the named pipe functionality)
-      const cmd = new RunProcess('watch', ['echo', 'hello'], { stdio: 'ignore' }, false, '/tmp/testpipe2')
+      const cmd = new RunProcess('watch', ['echo', 'hello'], undefined, false, '/tmp/testpipe2')
 
       await createNamedPipe(pipeLocation)
       await cmd.setupNamedPipeServer()

--- a/src/unix/run-process.ts
+++ b/src/unix/run-process.ts
@@ -392,6 +392,18 @@ export class RunProcess {
       })
     })
   }
+
+  /**
+   * When searching for specific stuff with waitForNamedPipeOutput(), it might be nice to wait for a specific case -> clear the data.
+   */
+  public clearNamedPipeOutDataStr(): void {
+    if (this.namedPipe === undefined || this.namedPipe.server === undefined) {
+      throw new NoNamedPipeError(
+        `Can't clear named pipe output, when it isn't setup! (Did you forget to call setupNamedPipeServer()?)`
+      )
+    }
+    this.namedPipe.outDataStr = ''
+  }
 }
 
 /**

--- a/src/unix/run-process.ts
+++ b/src/unix/run-process.ts
@@ -54,8 +54,8 @@ export class RunProcess {
     options = { env: process.env, ...options }
 
     // Exec or spawn command
-    // shouldExec ? (this.cmd = exec(command)) : (this.cmd = spawn(command, args || [], options))
-    this.cmd = spawn(command, args || [], options)
+    shouldExec ? (this.cmd = exec(command)) : (this.cmd = spawn(command, args || [], options))
+    // this.cmd = spawn(command, args || [], options)
     this.isExec = shouldExec
     this.detached = options.detached ? options.detached : false
 
@@ -234,7 +234,7 @@ export class RunProcess {
         this.cmd.kill('SIGKILL')
       }
     } else if (!this.stopped) {
-      throw new StandardStreamsStillOpenError('Process exited but standard steams are still open')
+      throw new StandardStreamsStillOpenError('Process exitted but standard steams are still open')
     }
 
     return await this.stopPromise


### PR DESCRIPTION
Kinda rough, the expected exit code differs when running `npx jest / npm test` vs `node_modules/.bin/jest` for some reason, so the expected result is very generic.

Does however work in the firmware setup now.