### PR TITLE
run-process: fix timeout hanging on waitForExit

### DIFF
--- a/src/unix/run-process.test.ts
+++ b/src/unix/run-process.test.ts
@@ -171,4 +171,17 @@ describe('run-process', () => {
     })
     await expect(cmd.waitForExit()).rejects.toThrow('spawn my-command-that-does-not-exist ENOENT')
   })
+
+  it('should not hang on waitForExit(), if the timeout is longer than the process runtime', async () => {
+    await commandEmulation.registerCommand('hangingTooLongTimeout', async () => {
+      console.log(`started`)
+      setTimeout(() => {
+        console.log(`hello`)
+      }, 100)
+    })
+    processCleanup.push()
+
+    const cmd = new RunProcess(`hangingTooLongTimeout`)
+    await expect(cmd.waitForOutput(new RegExp(`never comes up`), 2000)).rejects.toThrow(`started\nhello\n`)
+  })
 })

--- a/src/unix/run-process.ts
+++ b/src/unix/run-process.ts
@@ -142,9 +142,10 @@ export class RunProcess {
     outputs: Array<'stdout' | 'stderr'> = ['stdout', 'stderr']
   ): Promise<RegExpMatchArray> {
     const listeners: Array<['stdout' | 'stderr', (chunk: Buffer) => void]> = []
+    let timeoutHandle: NodeJS.Timeout | null = null
+
     try {
       return await new Promise((resolve, reject) => {
-        let timeoutHandle: NodeJS.Timeout | null = null
         if (timeout) {
           timeoutHandle = setTimeout(() => reject(new TimeoutError()), timeout)
         }
@@ -156,9 +157,6 @@ export class RunProcess {
             data += chunk.toString('utf8')
             const match = data.match(regex)
             if (match) {
-              if (timeoutHandle) {
-                clearTimeout(timeoutHandle)
-              }
               resolve(match)
             }
           }
@@ -172,6 +170,10 @@ export class RunProcess {
         })
       })
     } finally {
+      // Clear the timeout if we find input or not
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle)
+      }
       // Make sure we stop listening when match is found
       for (const [output, listener] of listeners) {
         this[output]?.removeListener('data', listener)


### PR DESCRIPTION
When running RunProcess waitForOutput will have a asynchronous setTimeOut
waiting in the background, which didn't get cleared if the output wasn't found
but the process still exited.