### PR TITLE
CRA jest should maintain the name for checks output

### DIFF
--- a/bin/checks.ts
+++ b/bin/checks.ts
@@ -167,7 +167,8 @@ async function lookupConvertFunction(
         const output = await runReactScriptsTest()
         return jestCheck({
           data: output,
-          sha: commitSha
+          sha: commitSha,
+          name: 'jest-cra'
         })
       }
     }

--- a/src/checks/jest/jest.ts
+++ b/src/checks/jest/jest.ts
@@ -7,12 +7,13 @@ export type JestOutput = FormattedTestResults
 export interface JestInput {
   sha: string
   data: FormattedTestResults
+  name?: string
 }
 
-export const jestCheck = ({ data, sha }: JestInput): CheckRunCompleted => {
+export const jestCheck = ({ data, sha, name = 'jest' }: JestInput): CheckRunCompleted => {
   try {
     const result: CheckRunCompleted = {
-      name: 'jest',
+      name,
       head_sha: sha,
       conclusion: 'neutral',
       status: 'completed',


### PR DESCRIPTION
`name` was changing during run:

![image](https://user-images.githubusercontent.com/1812228/103879931-c13b9e80-50d8-11eb-8367-25d99a81109a.png)
