### PR TITLE
Fixed cargo check for feature-gated code

### DIFF
--- a/src/checks/cargo/run-cargo-check.ts
+++ b/src/checks/cargo/run-cargo-check.ts
@@ -2,20 +2,24 @@ import { runJsonLinesCommand } from '../checks-common'
 import { touchRustFiles } from './cargo'
 import { CargoMessage } from './cargo-types'
 
-export async function runCargoCheck(args: string[] = []): Promise<CargoMessage[]> {
+export async function runCargoCheck(args: string[] = [], allFeatures = false): Promise<CargoMessage[]> {
   // Description for why this is needed, can be found
   // at the `touchRustFiles` definition
   await touchRustFiles()
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [exitInfo, json] = await runJsonLinesCommand<CargoMessage>('cargo', [
-    'check',
-    '--all-targets',
-    '--all-features',
-    '--locked',
-    '--message-format=json',
-    '--',
-    ...args
-  ])
+  const [exitInfo, json] = await runJsonLinesCommand<CargoMessage>(
+    'cargo',
+    [
+      'check',
+      '--all-targets',
+      allFeatures ? '--all-features' : '',
+      '--locked',
+      '--message-format=json',
+      '--',
+      ...args
+    ].filter(Boolean)
+  )
+
   return json
 }


### PR DESCRIPTION
Discovered the other day that feature-gated code wasn't always linted correctly.

-----

If `--all-features` was set vs unset, then it would yield different lints. So if you for instance had:

```
#[cfg(feature = "mock")]
use std::collections::HashMap;
```

Then assuming `HashMap` is an unused import, then it would ofc not lint without `--all-features`, but it would lint with `--all-features` as expected.

However, if we invert the condition like this:

```
#[cfg(not(feature = "mock"))]
use std::collections::HashMap;
```

Then again assuming it's an unused import, then it would lint without `--all-features`. However, it **wouldn't** emit the lint with `--all-features`, which was the issue as we always used `--all-features`. We couldn't just remove it, as then we'd no longer get a majority of lints for feature-gated code.

-----

The easiest solution I found, was to run `cargo check` 2 times with and without `--all-features`.

An alternative solution would be to be able to define sets of feature combinations, so the Rust checks can effectively produce the most lints across all combinations. _(I've created a story for the future: [ch-55417](https://app.clubhouse.io/connectedcars/story/55417/rust-checks-feature-sets))_

-----

[[ch-54718](https://app.clubhouse.io/connectedcars/story/54718/rust-checks-doesn-t-always-lint-feature-gated-code)]
