### PR TITLE
Update RUSTFLAGS if CI to forbid any blanket allow warnings

### DIFF
--- a/bin/checks.ts
+++ b/bin/checks.ts
@@ -4,7 +4,7 @@ import fs from 'fs'
 import util from 'util'
 import yargs from 'yargs'
 
-import { cargoHasBuildFinished } from '../src/checks/cargo/cargo'
+import { cargoHasBuildFinished, updateEnvRustFlags } from '../src/checks/cargo/cargo'
 import { cargoCheckCheck } from '../src/checks/cargo/cargo-check'
 import { cargoClippyCheck } from '../src/checks/cargo/cargo-clippy'
 import { cargoFmtCheck } from '../src/checks/cargo/cargo-fmt'
@@ -69,6 +69,10 @@ async function main(argv: string[]) {
   if (!COMMIT_SHA) {
     console.error('Missing environment variable "COMMIT_SHA"')
     return 1
+  }
+
+  if (flags.ci) {
+    updateEnvRustFlags(flags.ci)
   }
 
   const startedAt = new Date().toISOString()

--- a/src/checks/cargo/cargo.ts
+++ b/src/checks/cargo/cargo.ts
@@ -2,6 +2,21 @@ import { touchFiles } from '../../unix'
 import { CheckAnnotation } from '../checks-common'
 import { CargoBuildFinishedMessage, CargoCompilerMessage, CargoMessage, DiagnosticSpan } from './cargo-types'
 
+const DEFAULT_CI_RUSTFLAGS = '-F warnings -D unused'
+
+export function updateEnvRustFlags(ci: boolean): void {
+  let rustFlags = process.env['RUSTFLAGS'] || ''
+
+  if (ci) {
+    rustFlags += ' --cfg ci_build'
+
+    const ciRustFlags = process.env['CI_RUSTFLAGS'] ?? DEFAULT_CI_RUSTFLAGS
+    rustFlags += ` ${ciRustFlags}`
+  }
+
+  process.env['RUSTFLAGS'] = rustFlags.trim()
+}
+
 export function getCompilerAnnotations(item: CargoCompilerMessage): CheckAnnotation[] {
   // The `children` i.e. the child diagnostic messages can safely
   // be ignored, as they only provide additional information to


### PR DESCRIPTION
If `checks` is executed with `--ci`, then the `RUSTFLAGS` env var is appended with `CI_RUSTFLAGS`. If `CI_RUSTFLAGS` is not set, then it by default uses `-F warnings -D unused` to be able to forbid and deny any and every instance of `#[allow(warnings)]` and `#[allow(unused)]`.

For clarity, the reason we want to disallow those, is that using either of those two, is a blanket allow for many lints. So if someone wants to e.g. keep an unused import, then it's better to do `#[allow(unused_imports)]` as it only allows _that_, while with `#[allow(unused)]` you'll _accidentally_ allow a lot more.

Basically, we want to avoid needing to do stuff like this https://github.com/connectedcars/firmware_hal/pull/419 specifically this in [nebula.rs](https://github.com/connectedcars/firmware_hal/blob/ed5a66fe56de1b8ed189f67414fbd8a18da560fb/eol-test/src/can/nebula.rs#L3), as there was quite a lot of code to clean up, along with `Result`s being ignored.

-----

Additionally, if `--ci` then it also defines a `ci_build` config, which makes it possible to detect `--ci` in Rust-land by doing `#[cfg(ci_build)]`/`#[cfg(not(ci_build))]`.

-----

[[ch-52844](https://app.clubhouse.io/connectedcars/story/52844/forbid-suppressing-all-warnings-if-ci)]
