### PR TITLE
Reworked Rust checks to pass env to child process

### DIFF
--- a/src/checks/cargo/cargo.ts
+++ b/src/checks/cargo/cargo.ts
@@ -4,7 +4,7 @@ import { CargoBuildFinishedMessage, CargoCompilerMessage, CargoMessage, Diagnost
 
 const DEFAULT_CI_RUSTFLAGS = '-F warnings -D unused'
 
-export function updateEnvRustFlags(ci: boolean): void {
+export function getEnvRustFlags(ci: boolean): string {
   let rustFlags = process.env['RUSTFLAGS'] || ''
 
   if (ci) {
@@ -14,7 +14,7 @@ export function updateEnvRustFlags(ci: boolean): void {
     rustFlags += ` ${ciRustFlags}`
   }
 
-  process.env['RUSTFLAGS'] = rustFlags.trim()
+  return rustFlags.trim()
 }
 
 export function getCompilerAnnotations(item: CargoCompilerMessage): CheckAnnotation[] {

--- a/src/checks/cargo/run-cargo-check.ts
+++ b/src/checks/cargo/run-cargo-check.ts
@@ -1,15 +1,9 @@
-import { runJsonLinesCommand } from '../checks-common'
-import { touchRustFiles } from './cargo'
 import { CargoMessage } from './cargo-types'
+import { runCargo } from './run-cargo'
 
-export async function runCargoCheck(args: string[] = [], allFeatures = false): Promise<CargoMessage[]> {
-  // Description for why this is needed, can be found
-  // at the `touchRustFiles` definition
-  await touchRustFiles()
-
+export async function runCargoCheck(args: string[] = [], allFeatures = false, ci = true): Promise<CargoMessage[]> {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [exitInfo, json] = await runJsonLinesCommand<CargoMessage>(
-    'cargo',
+  const [exitInfo, json] = await runCargo(
     [
       'check',
       '--all-targets',
@@ -18,8 +12,8 @@ export async function runCargoCheck(args: string[] = [], allFeatures = false): P
       '--message-format=json',
       '--',
       ...args
-    ].filter(Boolean)
+    ].filter(Boolean),
+    ci
   )
-
   return json
 }

--- a/src/checks/cargo/run-cargo-check.ts
+++ b/src/checks/cargo/run-cargo-check.ts
@@ -3,7 +3,7 @@ import { runCargo } from './run-cargo'
 
 export async function runCargoCheck(args: string[] = [], allFeatures = false, ci = true): Promise<CargoMessage[]> {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [exitInfo, json] = await runCargo(
+  return runCargo(
     [
       'check',
       '--all-targets',
@@ -15,5 +15,4 @@ export async function runCargoCheck(args: string[] = [], allFeatures = false, ci
     ].filter(Boolean),
     ci
   )
-  return json
 }

--- a/src/checks/cargo/run-cargo-clippy.ts
+++ b/src/checks/cargo/run-cargo-clippy.ts
@@ -1,25 +1,15 @@
-import { runJsonLinesCommand } from '../checks-common'
-import { touchRustFiles } from './cargo'
 import { CargoMessage } from './cargo-types'
+import { runCargo } from './run-cargo'
 
-export async function runCargoClippy(args: string[] = []): Promise<CargoMessage[]> {
-  // Description for why this is needed, can be found
-  // at the `touchRustFiles` definition
-  await touchRustFiles()
-
+export async function runCargoClippy(args: string[] = [], ci = true): Promise<CargoMessage[]> {
   if (args.length == 0) {
     args = ['-D', 'clippy::all']
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [exitInfo, json] = await runJsonLinesCommand<CargoMessage>('cargo', [
-    'clippy',
-    '--all-targets',
-    '--all-features',
-    '--locked',
-    '--message-format=json',
-    '--',
-    ...args
-  ])
+  const [exitInfo, json] = await runCargo(
+    ['clippy', '--all-targets', '--all-features', '--locked', '--message-format=json', '--', ...args],
+    ci
+  )
   return json
 }

--- a/src/checks/cargo/run-cargo-clippy.ts
+++ b/src/checks/cargo/run-cargo-clippy.ts
@@ -7,9 +7,5 @@ export async function runCargoClippy(args: string[] = [], ci = true): Promise<Ca
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [exitInfo, json] = await runCargo(
-    ['clippy', '--all-targets', '--all-features', '--locked', '--message-format=json', '--', ...args],
-    ci
-  )
-  return json
+  return runCargo(['clippy', '--all-targets', '--all-features', '--locked', '--message-format=json', '--', ...args], ci)
 }

--- a/src/checks/cargo/run-cargo-fmt.ts
+++ b/src/checks/cargo/run-cargo-fmt.ts
@@ -1,18 +1,24 @@
 import { runJsonCommand } from '../checks-common'
+import { getEnvRustFlags, touchRustFiles } from './cargo'
 import { CargoFmtFile } from './cargo-types'
 
-export async function runCargoFmt(args: string[] = []): Promise<CargoFmtFile[]> {
+export async function runCargoFmt(args: string[] = [], ci = true): Promise<CargoFmtFile[]> {
+  // Description for why this is needed, can be found
+  // at the `touchRustFiles` definition
+  await touchRustFiles()
+
   // While cargo and clippy emits individual json objects, rustfmt does not
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [exitInfo, json] = await runJsonCommand<CargoFmtFile[]>('cargo', [
-    '+nightly',
-    'fmt',
-    '--',
-    '--emit=json',
-    '--color',
-    'never',
-    ...args
-  ])
+  const [exitInfo, json] = await runJsonCommand<CargoFmtFile[]>(
+    'cargo',
+    ['+nightly', 'fmt', '--', '--emit=json', '--color', 'never', ...args],
+    {
+      env: {
+        ...process.env,
+        RUSTFLAGS: getEnvRustFlags(ci)
+      }
+    }
+  )
   // TODO: If there is syntax errors then `cargo fmt` fails, which results in `json` being empty
   //       and in turn `cargoFmtCheck` passing. It might be useful to handle that case. However,
   //       it is less important, as `checks cargo-fmt` won't be used alone.

--- a/src/checks/cargo/run-cargo-fmt.ts
+++ b/src/checks/cargo/run-cargo-fmt.ts
@@ -1,26 +1,16 @@
 import { runJsonCommand } from '../checks-common'
-import { getEnvRustFlags, touchRustFiles } from './cargo'
 import { CargoFmtFile } from './cargo-types'
+import { runCargo } from './run-cargo'
 
 export async function runCargoFmt(args: string[] = [], ci = true): Promise<CargoFmtFile[]> {
-  // Description for why this is needed, can be found
-  // at the `touchRustFiles` definition
-  await touchRustFiles()
-
   // While cargo and clippy emits individual json objects, rustfmt does not
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [exitInfo, json] = await runJsonCommand<CargoFmtFile[]>(
-    'cargo',
+  return runCargo<CargoFmtFile>(
     ['+nightly', 'fmt', '--', '--emit=json', '--color', 'never', ...args],
-    {
-      env: {
-        ...process.env,
-        RUSTFLAGS: getEnvRustFlags(ci)
-      }
-    }
+    ci,
+    runJsonCommand
   )
   // TODO: If there is syntax errors then `cargo fmt` fails, which results in `json` being empty
   //       and in turn `cargoFmtCheck` passing. It might be useful to handle that case. However,
   //       it is less important, as `checks cargo-fmt` won't be used alone.
-  return json
 }

--- a/src/checks/cargo/run-cargo-test.ts
+++ b/src/checks/cargo/run-cargo-test.ts
@@ -1,18 +1,21 @@
-import { runJsonLinesCommand } from '../checks-common'
 import { CargoMessage } from './cargo-types'
+import { runCargo } from './run-cargo'
 
-export async function runCargoTest(args: string[] = []): Promise<CargoMessage[]> {
+export async function runCargoTest(args: string[] = [], ci = true): Promise<CargoMessage[]> {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [exitInfo, json] = await runJsonLinesCommand<CargoMessage>('cargo', [
-    'test',
-    '--all-targets',
-    '--locked',
-    '--message-format=json',
-    '--',
-    '-Zunstable-options',
-    '--format=json',
-    // '--report-time',
-    ...args
-  ])
+  const [exitInfo, json] = await runCargo(
+    [
+      'test',
+      '--all-targets',
+      '--locked',
+      '--message-format=json',
+      '--',
+      '-Zunstable-options',
+      '--format=json',
+      // '--report-time',
+      ...args
+    ],
+    ci
+  )
   return json
 }

--- a/src/checks/cargo/run-cargo-test.ts
+++ b/src/checks/cargo/run-cargo-test.ts
@@ -3,7 +3,7 @@ import { runCargo } from './run-cargo'
 
 export async function runCargoTest(args: string[] = [], ci = true): Promise<CargoMessage[]> {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [exitInfo, json] = await runCargo(
+  return runCargo(
     [
       'test',
       '--all-targets',
@@ -17,5 +17,4 @@ export async function runCargoTest(args: string[] = [], ci = true): Promise<Carg
     ],
     ci
   )
-  return json
 }

--- a/src/checks/cargo/run-cargo.ts
+++ b/src/checks/cargo/run-cargo.ts
@@ -1,0 +1,18 @@
+import { ExitInformation } from '../../unix'
+import { runJsonLinesCommand } from '../checks-common'
+import { getEnvRustFlags, touchRustFiles } from './cargo'
+import { CargoMessage } from './cargo-types'
+
+export async function runCargo(args: string[], ci = true): Promise<[ExitInformation, CargoMessage[]]> {
+  // Description for why this is needed, can be found
+  // at the `touchRustFiles` definition
+  await touchRustFiles()
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  return runJsonLinesCommand<CargoMessage>('cargo', args, {
+    env: {
+      ...process.env,
+      RUSTFLAGS: getEnvRustFlags(ci)
+    }
+  })
+}


### PR DESCRIPTION
Resolved the issue. Now it instead passes a new associate array, with a shallow clone of the remaining entries of `process.env`.

~(Attempted to make `runCargo` generic, so it could be used for `runCargoFmt` as well, but it gave some weird runtime errors, while none at _compile_ time)~

[[ch-55542](https://app.clubhouse.io/connectedcars/story/55542/pass-env-to-child-process-instead-of-overriding-global-env-vars)]
