### PR TITLE
Changed to only require COMMIT_SHA if --ci

### DIFF
--- a/bin/checks.ts
+++ b/bin/checks.ts
@@ -66,8 +66,8 @@ async function main(argv: string[]) {
 
   const [command, ...args] = commandAndArgs.map(a => a.toString())
 
-  const COMMIT_SHA = process.env.COMMIT_SHA
-  if (!COMMIT_SHA) {
+  const COMMIT_SHA = process.env.COMMIT_SHA || ''
+  if (flags.ci && COMMIT_SHA.length == 0) {
     console.error('Missing environment variable "COMMIT_SHA"')
     return 1
   }


### PR DESCRIPTION
Changed to only require `COMMIT_SHA` if `--ci`. All CIs are using `--ci`, so this should be fine.

It's _only_ to remove a minor annoyance of needing to do `export COMMIT_SHA="dummy"` when opening a terminal (without having it defined in e.g. .bashrc).

(There's another issue I want to look at too, so a new release can wait)

[[ch-56655](https://app.clubhouse.io/connectedcars/story/56655/only-require-commit-sha-if-ci)]