### PR TITLE
Fixed cargo test not running doc tests

### DIFF
--- a/bin/checks.ts
+++ b/bin/checks.ts
@@ -13,7 +13,7 @@ import { CargoMessage } from '../src/checks/cargo/cargo-types'
 import { runCargoCheck } from '../src/checks/cargo/run-cargo-check'
 import { runCargoClippy } from '../src/checks/cargo/run-cargo-clippy'
 import { runCargoFmt } from '../src/checks/cargo/run-cargo-fmt'
-import { runCargoTest } from '../src/checks/cargo/run-cargo-test'
+import { runCargoDocTest, runCargoTest } from '../src/checks/cargo/run-cargo-test'
 import { CheckConversionError, CheckRunCompleted, printSummary } from '../src/checks/checks-common'
 import { eslintCheck } from '../src/checks/eslint/eslint'
 import { runEslint } from '../src/checks/eslint/run-eslint'
@@ -319,7 +319,8 @@ async function lookupConvertFunction(
         return null
       }
       return async () => {
-        const output = await runCargoTest(args, ci)
+        const outputs = [await runCargoTest(args, ci), await runCargoDocTest(args, ci)]
+        const output = ([] as CargoMessage[]).concat(...outputs)
         return [
           false,
           cargoTestCheck({

--- a/src/checks/cargo/run-cargo-test.ts
+++ b/src/checks/cargo/run-cargo-test.ts
@@ -18,3 +18,22 @@ export async function runCargoTest(args: string[] = [], ci = true): Promise<Carg
     ci
   )
 }
+
+// Issue: https://github.com/rust-lang/cargo/issues/6669
+export async function runCargoDocTest(args: string[] = [], ci = true): Promise<CargoMessage[]> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  return runCargo(
+    [
+      'test',
+      '--doc',
+      '--locked',
+      '--message-format=json',
+      '--',
+      '-Zunstable-options',
+      '--format=json',
+      // '--report-time',
+      ...args
+    ],
+    ci
+  )
+}


### PR DESCRIPTION
Fixed so `checks cargo-test` now runs doc tests. Apparently `--all-targets` and `--doc` does not mix, so it needs to run `cargo test` twice.

[[sc-62453](https://app.shortcut.com/connectedcars/story/62453/rust-checks-skips-doc-tests)]