### PR TITLE
Fixed cargo doc test for bin crates

### DIFF
--- a/src/checks/cargo/run-cargo-test.ts
+++ b/src/checks/cargo/run-cargo-test.ts
@@ -1,3 +1,4 @@
+import { CommandJSONConversionError } from '../checks-common'
 import { CargoMessage } from './cargo-types'
 import { runCargo } from './run-cargo'
 
@@ -21,19 +22,30 @@ export async function runCargoTest(args: string[] = [], ci = true): Promise<Carg
 
 // Issue: https://github.com/rust-lang/cargo/issues/6669
 export async function runCargoDocTest(args: string[] = [], ci = true): Promise<CargoMessage[]> {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  return runCargo(
-    [
-      'test',
-      '--doc',
-      '--locked',
-      '--message-format=json',
-      '--',
-      '-Zunstable-options',
-      '--format=json',
-      // '--report-time',
-      ...args
-    ],
-    ci
-  )
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    return await runCargo(
+      [
+        'test',
+        '--doc',
+        '--locked',
+        '--message-format=json',
+        '--',
+        '-Zunstable-options',
+        '--format=json',
+        // '--report-time',
+        ...args
+      ],
+      ci
+    )
+  } catch (e) {
+    if (e instanceof CommandJSONConversionError) {
+      if (e.stderr.trimLeft().startsWith('error: no library targets found in package')) {
+        // Executing `cargo test --doc` for non-library crates is not supported
+        return []
+      }
+    }
+
+    throw e
+  }
 }


### PR DESCRIPTION
Executing `cargo test --doc` for bin-only crates is not supported and will emit an error. This is a workaround to suppress that, so CI doesn't fail for bin-only projects.

[[sc-63080](https://app.shortcut.com/connectedcars/story/63080/rust-checks-skips-doc-tests-for-bin-crates)]