### PR TITLE
Added check for Rust release build

### DIFF
--- a/bin/checks.ts
+++ b/bin/checks.ts
@@ -287,7 +287,16 @@ async function lookupConvertFunction(
         // then `cargo check` needs to be executed twice, both with and
         // without `--all-features`.
         // See more at https://github.com/connectedcars/node-test/pull/55
-        const outputs = [await runCargoCheck(args, false, ci), await runCargoCheck(args, true, ci)]
+        const outputs = [
+          // Debug build
+          await runCargoCheck(args, false, ci),
+          // Debug build - all features
+          await runCargoCheck(args, true, ci),
+          // Release build
+          await runCargoCheck(args, false, ci, true),
+          // Release build - all features
+          await runCargoCheck(args, true, ci, true)
+        ]
         const output = ([] as CargoMessage[]).concat(...outputs)
         const skipRest = outputs.some(output => !cargoHasBuildFinished(output))
         return [

--- a/src/checks/cargo/run-cargo-check.ts
+++ b/src/checks/cargo/run-cargo-check.ts
@@ -1,11 +1,17 @@
 import { CargoMessage } from './cargo-types'
 import { runCargo } from './run-cargo'
 
-export async function runCargoCheck(args: string[] = [], allFeatures = false, ci = true): Promise<CargoMessage[]> {
+export async function runCargoCheck(
+  args: string[] = [],
+  allFeatures = false,
+  ci = true,
+  releaseBuild = false
+): Promise<CargoMessage[]> {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   return runCargo(
     [
       'check',
+      releaseBuild ? '--release' : '',
       '--all-targets',
       allFeatures ? '--all-features' : '',
       '--locked',


### PR DESCRIPTION
[[sc-64429](https://app.shortcut.com/connectedcars/story/64429/rust-checks-fail-to-catch-non-debug-lints)]