### PR TITLE
Fixed RUSTFLAGS for Rust 1.54

### DIFF
--- a/src/checks/cargo/cargo.ts
+++ b/src/checks/cargo/cargo.ts
@@ -2,7 +2,11 @@ import { touchFiles } from '../../unix'
 import { CheckAnnotation } from '../checks-common'
 import { CargoBuildFinishedMessage, CargoCompilerMessage, CargoMessage, DiagnosticSpan } from './cargo-types'
 
-const DEFAULT_CI_RUSTFLAGS = '-F warnings -D unused'
+// In newer versions, doing `#![forbid(warnings)]` is not allowed
+// and triggers the `forbidden_lint_groups` lint.
+// Issue: https://github.com/rust-lang/rust/issues/81670
+// Reference: https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#forbidden-lint-groups
+const DEFAULT_CI_RUSTFLAGS = '-D warnings -D unused'
 
 export function getEnvRustFlags(ci: boolean): string {
   let rustFlags = process.env['RUSTFLAGS'] || ''


### PR DESCRIPTION
This is safe to merge. While it is related to bumping to Rust 1.54, it does not affect using the Rust checks with Rust 1.49.

Related: [[sc-64076](https://app.shortcut.com/connectedcars/story/64076/bump-rust-1-54)]
Related: [[sc-63760](https://app.shortcut.com/connectedcars/story/63760/rust-checks-produce-broken-output-and-cause-ci-to-fail)]
