### PR TITLE
Minimized when recompilation is triggered for Rust

### DIFF
--- a/bin/checks.ts
+++ b/bin/checks.ts
@@ -297,8 +297,8 @@ async function lookupConvertFunction(
           // Release build - all features
           await runCargoCheck(args, true, ci, true)
         ]
-        const output = ([] as CargoMessage[]).concat(...outputs)
         const skipRest = outputs.some(output => !cargoHasBuildFinished(output))
+        const output = ([] as CargoMessage[]).concat(...outputs)
         return [
           skipRest,
           cargoCheckCheck({

--- a/src/checks/cargo/cargo.ts
+++ b/src/checks/cargo/cargo.ts
@@ -21,6 +21,40 @@ export function getEnvRustFlags(ci: boolean): string {
   return rustFlags.trim()
 }
 
+export function getRustEnv(
+  workspacePath: string,
+  releaseBuild: boolean,
+  allFeatures: boolean,
+  ci: boolean
+): { [key: string]: string } {
+  return {
+    ...process.env,
+    RUSTFLAGS: getEnvRustFlags(ci),
+    CARGO_TARGET_DIR: createRustTargetPath(workspacePath, releaseBuild, allFeatures, ci)
+  }
+}
+
+// Assumes that `CARGO_MANIFEST_DIR` is not present, or that
+// it is not different from the current working directory.
+export function createRustTargetPath(
+  workspacePath: string,
+  releaseBuild: boolean,
+  allFeatures: boolean,
+  ci: boolean
+): string {
+  // Currently we don't have anything where using `--all-targets`
+  // triggers any dependencies to get rebuild. So currently, it is
+  // not used.
+  // This also means that build times are quicker, since half the
+  // builds will share the same target directory.
+  return (
+    `${workspacePath}/target/checks-` +
+    (releaseBuild ? 'release' : 'debug') +
+    // (allFeatures ? '-all' : '') +
+    (ci ? '-ci' : '')
+  )
+}
+
 export function getCompilerAnnotations(item: CargoCompilerMessage): CheckAnnotation[] {
   // The `children` i.e. the child diagnostic messages can safely
   // be ignored, as they only provide additional information to

--- a/src/checks/cargo/run-cargo-locate-workspace.ts
+++ b/src/checks/cargo/run-cargo-locate-workspace.ts
@@ -1,0 +1,22 @@
+import path from 'path'
+
+import { runCommand } from '../checks-common'
+
+let WORKSPACE_PATH: string | null = null
+
+export async function runCargoLocateWorkspace(): Promise<string> {
+  if (WORKSPACE_PATH !== null) {
+    return WORKSPACE_PATH
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { exitInfo, stdout, stderr } = await runCommand('cargo', [
+    'locate-project',
+    '--workspace',
+    '--message-format=plain'
+  ])
+
+  WORKSPACE_PATH = path.parse(stdout.trim()).dir
+
+  return WORKSPACE_PATH
+}


### PR DESCRIPTION
[[sc-64454](https://app.shortcut.com/connectedcars/story/64454/rust-checks-build-into-different-target-dirs)]
Partially: [[sc-61799](https://app.shortcut.com/connectedcars/story/61799/checks-cargo-clippy-always-rebuilds-all-dependencies)]