### PR TITLE
Fixed to handle manifest parse errors

### DIFF
--- a/src/checks/cargo/cargo-check.ts
+++ b/src/checks/cargo/cargo-check.ts
@@ -1,6 +1,6 @@
 import { filterDuplicates } from '../../common'
 import { CheckAnnotation, CheckRunCompleted } from '../checks-common'
-import { getCompilerAnnotations } from './cargo'
+import { createAnnotationFromManifestError, getCompilerAnnotations } from './cargo'
 import { CargoMessage } from './cargo-types'
 
 // TODO: Implement more than just errors: https://github.com/actions-rs/clippy-check/blob/master/src/check.ts
@@ -51,6 +51,9 @@ export function cargoCheckCheck({ data, sha }: CargoCheckInput): CheckRunComplet
         // is already regarded as something that must be resolved.
         // Thus map all messages into failures.
         annotations.push(...getCompilerAnnotations(item))
+      } else if (item.reason === 'manifest-parse-error') {
+        stats.error += 1
+        annotations.push(createAnnotationFromManifestError(item))
       }
     }
 

--- a/src/checks/cargo/cargo-clippy.ts
+++ b/src/checks/cargo/cargo-clippy.ts
@@ -1,6 +1,6 @@
 import { filterDuplicates } from '../../common'
 import { CheckAnnotation, CheckRunCompleted } from '../checks-common'
-import { getCompilerAnnotations, isMessageFromDependency } from './cargo'
+import { createAnnotationFromManifestError, getCompilerAnnotations, isMessageFromDependency } from './cargo'
 import { CargoMessage } from './cargo-types'
 
 // TODO: Implement more than just errors: https://github.com/actions-rs/clippy-check/blob/master/src/check.ts
@@ -59,6 +59,9 @@ export function cargoClippyCheck({ data, sha }: CargoClippyInput): CheckRunCompl
         // is already regarded as something that must be resolved.
         // Thus map all messages into failures.
         annotations.push(...getCompilerAnnotations(item))
+      } else if (item.reason === 'manifest-parse-error') {
+        stats.error += 1
+        annotations.push(createAnnotationFromManifestError(item))
       }
     }
 

--- a/src/checks/cargo/cargo-test.ts
+++ b/src/checks/cargo/cargo-test.ts
@@ -1,5 +1,6 @@
 import { filterDuplicates } from '../../common'
 import { CheckAnnotation, CheckRunCompleted } from '../checks-common'
+import { createAnnotationFromManifestError } from './cargo'
 import { CargoMessage, CargoTestMessage } from './cargo-types'
 
 export interface CargoTestInput {
@@ -31,7 +32,9 @@ function getTestAnnotations(item: CargoTestMessage): CheckAnnotation[] {
 function getAnnotations(data: CargoMessage[]): CheckAnnotation[] {
   const annotations: CheckAnnotation[] = []
   for (const item of data) {
-    if (item.type === 'test' && item.event === 'failed') {
+    if (item.reason === 'manifest-parse-error') {
+      annotations.push(createAnnotationFromManifestError(item))
+    } else if (item.type === 'test' && item.event === 'failed') {
       annotations.push(...getTestAnnotations(item))
     }
   }

--- a/src/checks/cargo/cargo-types.ts
+++ b/src/checks/cargo/cargo-types.ts
@@ -8,6 +8,7 @@ export type CargoMessage =
   | CargoCompilerArtifact
   | CargoTestMessage
   | CargoSuiteMessage
+  | CargoManifestParseError
 
 // JSON output from `cargo test` is currently
 // unstable, so the format is undocumented,
@@ -181,7 +182,10 @@ export interface DiagnosticExpansion {
   def_site_span: DiagnosticSpan | null
 }
 
+export type CargoFmtMessage = CargoFmtFile | CargoManifestParseError
+
 export interface CargoFmtFile {
+  reason?: undefined
   name: string
   mismatches: CargoFmtMismatch[]
 }
@@ -193,4 +197,14 @@ export interface CargoFmtMismatch {
   expected_end_line: number
   original: string
   expected: string
+}
+
+// Not an official Rust nor Cargo message, it's
+// one `checks` produces on the given error.
+export interface CargoManifestParseError {
+  type?: undefined
+  reason: 'manifest-parse-error'
+  path: string
+  title: string
+  error: string
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -23,7 +23,7 @@ export function filterDuplicates<T>(items: T[]): T[] {
 }
 
 export function stripPrefix(str: string, prefix: string): string {
-  if (str.indexOf(prefix) === 0) {
+  if (str.startsWith(prefix)) {
     return str.slice(prefix.length)
   } else {
     return str


### PR DESCRIPTION
[[sc-65915](https://app.shortcut.com/connectedcars/story/65915/rust-checks-are-not-skipped-if-cargo-toml-has-issues)]