### PR TITLE
Implemented Rust manifest check

### DIFF
--- a/src/checks/cargo/cargo-sort.ts
+++ b/src/checks/cargo/cargo-sort.ts
@@ -1,0 +1,102 @@
+import { basename } from 'path'
+
+import { filterDuplicates } from '../../common'
+import { CheckAnnotation, CheckRunCompleted } from '../checks-common'
+import { collectAnnotations, collectCargoManifestParseErrors } from './cargo'
+import { CargoManifestParseError } from './cargo-types'
+import { runCargoLocateWorkspace } from './run-cargo-locate-workspace'
+import { CargoSortMessage } from './run-cargo-sort'
+
+export interface CargoSortInput {
+  sha: string
+  data: (CargoSortMessage | CargoManifestParseError)[]
+}
+
+export async function cargoSortCheck({ data, sha }: CargoSortInput): Promise<CheckRunCompleted> {
+  if (!Array.isArray(data)) {
+    return {
+      name: 'cargo-sort',
+      head_sha: sha,
+      conclusion: 'skipped',
+      status: 'completed',
+      completed_at: new Date().toISOString(),
+      output: {
+        title: 'Unexpected sort output',
+        summary: ''
+      }
+    }
+  }
+
+  const workspacePath = await runCargoLocateWorkspace()
+  const rootName = basename(workspacePath)
+
+  // eslint-disable-next-line prefer-const
+  let [annotations, stats] = collectAnnotations(data, (item, annotations, stats) => {
+    if (item.reason === 'manifest-parse-error') {
+      collectCargoManifestParseErrors(item, annotations, stats)
+    } else {
+      // This assumes that there are no crates within the workspace with the same name
+      const path = item.crate === null || item.crate === rootName ? 'Cargo.toml' : `${item.crate}/Cargo.toml`
+
+      let message = item.error
+      if (item.manifest !== null) {
+        message += `\nExpected:\n${item.manifest}`
+      }
+
+      const annotation: CheckAnnotation = {
+        path,
+        start_line: 0,
+        end_line: 0,
+        annotation_level: 'failure',
+        message,
+        title: item.error,
+        raw_details: JSON.stringify(message, null, 4)
+      }
+
+      annotations.push(annotation)
+      stats.error += 1
+    }
+  })
+
+  if (annotations.length > 0) {
+    annotations = filterDuplicates(annotations)
+
+    const summary = `Total of ${annotations.length} ${annotations.length === 1 ? 'issue' : 'issues'}`
+    return {
+      name: 'cargo-sort',
+      head_sha: sha,
+      conclusion: 'failure',
+      status: 'completed',
+      completed_at: new Date().toISOString(),
+      output: {
+        title: summary,
+        summary,
+        text: [
+          '## Results',
+          '',
+          '| Message level           | Amount |',
+          '| ----------------------- | ------ |',
+          '| Internal compiler error | ' + `${stats.ice}`.padStart(6) + ' |',
+          '| Error                   | ' + `${stats.error}`.padStart(6) + ' |',
+          '| Warning                 | ' + `${stats.warning}`.padStart(6) + ' |',
+          '| Note                    | ' + `${stats.note}`.padStart(6) + ' |',
+          '| Help                    | ' + `${stats.help}`.padStart(6) + ' |'
+        ].join('\n'),
+        annotations
+      }
+    }
+  } else {
+    return {
+      name: 'cargo-sort',
+      head_sha: sha,
+      conclusion: 'success',
+      status: 'completed',
+      completed_at: new Date().toISOString(),
+      output: {
+        title: 'Found no issues',
+        summary: 'Found no issues',
+        annotations: []
+      }
+    }
+  }
+}

--- a/src/checks/cargo/run-cargo-locate-workspace.ts
+++ b/src/checks/cargo/run-cargo-locate-workspace.ts
@@ -1,6 +1,7 @@
 import path from 'path'
 
 import { ExitInformation } from '../..'
+import { splitLines } from '../../common'
 import { runCommand } from '../checks-common'
 
 let WORKSPACE_PATH: string | null = null
@@ -31,7 +32,7 @@ export class CargoLocateWorkspaceError extends Error {
   public stderr: string
 
   public constructor(exitInfo: ExitInformation, stdout: string, stderr: string) {
-    const err = stderr.split('\n')[0]
+    const err = splitLines(stderr)[0]
 
     super(`cargo locate workspace failed: ${err}`)
 

--- a/src/checks/cargo/run-cargo-sort.ts
+++ b/src/checks/cargo/run-cargo-sort.ts
@@ -1,0 +1,147 @@
+import { splitLines } from '../../common'
+import { CommandOutput, runCommand } from '../checks-common'
+
+const ORDER = 'workspace,package,lib,bin,features,dependencies,dev-dependencies,profile'
+
+// These are intentionally case sensitive
+const RE_CHECKING_CRATE = /^Checking\s+([\w-]+)...$/
+const RE_ERROR = /^error:\s+(.*)$/
+const RE_FOR_CRATE = /for\s+([\w-]+)/
+
+export interface CargoSortMessage {
+  reason?: undefined
+  error: string
+  crate: string | null
+  manifest: string | null
+}
+
+interface CargoSortCheckError {
+  error: string
+  crate: string | null
+}
+
+type CargoSortPrintCrates = { [key: string]: string }
+
+export async function runCargoSort(args: string[] = []): Promise<CargoSortMessage[]> {
+  const errors = await runCargoSortCheck(args)
+  if (errors.length == 0) {
+    return []
+  }
+
+  // Needs two passes, as `--check` emits which manifests have issues,
+  // while `--print` emits all manifests in the expected format
+  const crates = await runCargoSortPrint(args)
+
+  const output = []
+  for (const err of errors) {
+    output.push({
+      error: err.error,
+      crate: err.crate,
+      manifest: err.crate ? crates[err.crate] ?? null : null
+    })
+  }
+
+  return output
+}
+
+export async function runCargoSortCheck(args: string[] = []): Promise<CargoSortCheckError[]> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { exitInfo, stdout, stderr } = await runCargoSortCommand('--check', args)
+
+  const errors = []
+
+  for (const line of splitLines(stderr)) {
+    const error = parseError(line)
+    if (error == null) {
+      continue
+    }
+
+    errors.push({
+      error,
+      crate: parseForCrate(line)
+    })
+  }
+
+  return errors
+}
+
+export async function runCargoSortPrint(args: string[] = []): Promise<CargoSortPrintCrates> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { exitInfo, stdout, stderr } = await runCargoSortCommand('--print', args)
+  return parseOutput(stdout)
+}
+
+export async function runCargoSortCommand(command: string, args: string[] = []): Promise<CommandOutput> {
+  return runCommand('cargo', ['sort', command, '--grouped', '--workspace', '--order', ORDER, ...args].filter(Boolean), {
+    env: {
+      ...process.env,
+      NO_COLOR: 'true'
+    }
+  })
+}
+
+function parseOutput(output: string): CargoSortPrintCrates {
+  const crates: CargoSortPrintCrates = {}
+  let last = null
+
+  for (const line of splitLines(output)) {
+    const crate = parseChecking(line)
+    if (crate !== null) {
+      if (last !== null) {
+        crates[last.crate] = last.toml
+      }
+
+      last = {
+        crate,
+        toml: ''
+      }
+    } else if (last !== null) {
+      // `last` will always be non-null in this case, the check is to make eslint happy
+
+      if (last.toml.length > 0) {
+        last.toml += '\n'
+      }
+
+      last.toml += line
+    }
+  }
+
+  if (last !== null) {
+    crates[last.crate] = last.toml
+  }
+
+  return crates
+}
+
+function parseChecking(line: string): string | null {
+  const match = RE_CHECKING_CRATE.exec(line)
+  if (match == null) {
+    return null
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [_input, crate_name] = match
+  return crate_name
+}
+
+function parseError(line: string): string | null {
+  const match = RE_ERROR.exec(line)
+  if (match == null) {
+    return null
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [_input, err] = match
+  return err
+}
+
+function parseForCrate(line: string): string | null {
+  const match = RE_FOR_CRATE.exec(line)
+  if (match == null) {
+    return null
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [_input, crate_name] = match
+  return crate_name
+}

--- a/src/checks/cargo/run-cargo.ts
+++ b/src/checks/cargo/run-cargo.ts
@@ -1,6 +1,6 @@
 import { SpawnOptions } from 'child_process'
 
-import { stripPrefix } from '../../common'
+import { splitLines, stripPrefix } from '../../common'
 import { ExitInformation, touchFiles } from '../../unix'
 import { CommandJSONConversionError, runJsonLinesCommand } from '../checks-common'
 import { CargoManifestParseError } from './cargo-types'
@@ -128,7 +128,7 @@ function parseCargoManifestParseError(error: string): CargoManifestParseError {
     reason: 'manifest-parse-error',
     // Path must be relative to the root of the repository
     path: parseCargoManifestParseErrorPath(error) ?? 'Cargo.toml',
-    title: error.split('\n')[0],
+    title: splitLines(error)[0],
     error
   }
 }

--- a/src/checks/checks-common.ts
+++ b/src/checks/checks-common.ts
@@ -1,6 +1,6 @@
 // https://docs.github.com/en/rest/reference/checks#runs
 
-import { Json } from '../common'
+import { Json, splitLines } from '../common'
 import { ExitInformation, RunProcess } from '../unix/run-process'
 
 export type CheckAnnotationLevel = 'notice' | 'warning' | 'failure'
@@ -124,10 +124,7 @@ export async function runJsonLinesCommand<T = Json>(
   try {
     // Trimming whitespace from the ends, as otherwise an empty line
     // would result in `Unexpected end of JSON input`
-    const blobs = stdout
-      .trim()
-      .split('\n')
-      .map(line => JSON.parse(line))
+    const blobs = splitLines(stdout.trim()).map(line => JSON.parse(line))
     return [exitInfo, blobs]
   } catch (e) {
     throw new CommandJSONConversionError(command, args, stdout, stderr, e)

--- a/src/checks/tsc/run-tsc.ts
+++ b/src/checks/tsc/run-tsc.ts
@@ -1,3 +1,4 @@
+import { splitLines } from '../../common'
 import { RunProcess } from '../../unix/run-process'
 import { TscData } from './tsc-types'
 
@@ -12,7 +13,7 @@ function matchToObj(match: RegExpExecArray): TscData {
 }
 
 export function parseTsc(output: string): TscData[] {
-  const messages = output.split('\n')
+  const messages = splitLines(output)
 
   const tscErrorRegex = /^((?:[\w-]+\/)*[\w.-]+)\((\d+),(\d+)\): error (TS\d+): (.*)/
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -8,6 +8,8 @@ export type Json = null | boolean | number | string | Json[] | { [prop: string]:
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type TypedSinonStub<A extends (...args: any) => any> = sinon.SinonStub<Parameters<A>, ReturnType<A>>
 
+const RE_LINES = /\r?\n/
+
 // Returns a new array of all unique items in `items`.
 // Filters duplicates based on structural equality, i.e.
 // it uses `deepEqual()`.
@@ -28,4 +30,8 @@ export function stripPrefix(str: string, prefix: string): string {
   } else {
     return str
   }
+}
+
+export function splitLines(str: string): string[] {
+  return str.split(RE_LINES)
 }

--- a/src/mysql/mysqld-utils.ts
+++ b/src/mysql/mysqld-utils.ts
@@ -3,6 +3,7 @@ import os from 'os'
 import path from 'path'
 import util from 'util'
 
+import { splitLines } from '../common'
 import { pathExists, RunProcess } from '../unix'
 import { isFileNotFoundError } from '../unix/errors'
 
@@ -55,7 +56,7 @@ export async function getMySQLServerDefaults(mysqldPath: string, mysqlBaseDir?: 
   const variables: { [key: string]: string } = {}
   const variablesSection = output.toString().match(/Variables.+?Value.+?-{50,}\s+-{10}.+?\n(.+?)\n\n/s)
   if (variablesSection != null) {
-    for (const variableLine of variablesSection[1].split('\n')) {
+    for (const variableLine of splitLines(variablesSection[1])) {
       const variableMatch = variableLine.match(/^([^\s]+)\s+(.+?)$/)
       if (variableMatch) {
         variables[variableMatch[1]] = variableMatch[2]

--- a/src/unix/linux.ts
+++ b/src/unix/linux.ts
@@ -2,6 +2,8 @@ import childProcess from 'child_process'
 import fs from 'fs'
 import util from 'util'
 
+import { splitLines } from '../common'
+
 const execAsync = util.promisify(childProcess.exec)
 
 export async function isDockerOverlay2(): Promise<boolean> {
@@ -10,7 +12,7 @@ export async function isDockerOverlay2(): Promise<boolean> {
   }
   const cGroups = fs.readFileSync(`/proc/1/cgroup`).toString()
   if (cGroups.match(/^\d+:[^:]+:\/docker/)) {
-    const mounts = await execAsync(`mount`).toString().split('\n')
+    const mounts = splitLines(await execAsync(`mount`).toString())
     if (mounts.some(mount => mount.match(/overlay.*overlay2/) !== null)) {
       return true
     }


### PR DESCRIPTION
Implemented a new Rust manifest check that uses `cargo sort`. This requires `cargo-sort` to be installed, so currently it is not enabled by default.

[[sc-65744](https://app.shortcut.com/connectedcars/story/65744/rust-check-for-dependency-order)]