### PR TITLE
Streamlined duplicate code for check result

### DIFF
--- a/src/checks/cargo/__snapshots__/cargo-check.test.ts.snap
+++ b/src/checks/cargo/__snapshots__/cargo-check.test.ts.snap
@@ -8,7 +8,7 @@ Object {
   "name": "cargo-check",
   "output": Object {
     "summary": "",
-    "title": "Unexpected check output",
+    "title": "Unexpected cargo-check output",
   },
   "status": "completed",
 }

--- a/src/checks/cargo/__snapshots__/cargo-clippy.test.ts.snap
+++ b/src/checks/cargo/__snapshots__/cargo-clippy.test.ts.snap
@@ -8,7 +8,7 @@ Object {
   "name": "cargo-clippy",
   "output": Object {
     "summary": "",
-    "title": "Unexpected clippy output",
+    "title": "Unexpected cargo-clippy output",
   },
   "status": "completed",
 }

--- a/src/checks/cargo/__snapshots__/cargo-fmt.test.ts.snap
+++ b/src/checks/cargo/__snapshots__/cargo-fmt.test.ts.snap
@@ -8,7 +8,7 @@ Object {
   "name": "cargo-fmt",
   "output": Object {
     "summary": "",
-    "title": "Unexpected cargo fmt output",
+    "title": "Unexpected cargo-fmt output",
   },
   "status": "completed",
 }
@@ -236,6 +236,15 @@ Expected: ",
       },
     ],
     "summary": "Total of 11 issues",
+    "text": "## Results
+
+| Message level           | Amount |
+| ----------------------- | ------ |
+| Internal compiler error |      0 |
+| Error                   |     11 |
+| Warning                 |      0 |
+| Note                    |      0 |
+| Help                    |      0 |",
     "title": "Total of 11 issues",
   },
   "status": "completed",

--- a/src/checks/cargo/__snapshots__/cargo-test.test.ts.snap
+++ b/src/checks/cargo/__snapshots__/cargo-test.test.ts.snap
@@ -26,6 +26,15 @@ note: run with \`RUST_BACKTRACE=1\` environment variable to display a backtrace
       },
     ],
     "summary": "Total of 1 issue",
+    "text": "## Results
+
+| Message level           | Amount |
+| ----------------------- | ------ |
+| Internal compiler error |      0 |
+| Error                   |      1 |
+| Warning                 |      0 |
+| Note                    |      0 |
+| Help                    |      0 |",
     "title": "Total of 1 issue",
   },
   "status": "completed",
@@ -40,7 +49,7 @@ Object {
   "name": "cargo-test",
   "output": Object {
     "summary": "",
-    "title": "Unexpected test output",
+    "title": "Unexpected cargo-test output",
   },
   "status": "completed",
 }
@@ -53,8 +62,9 @@ Object {
   "head_sha": "11963e3cb7ecbb9247f638cc0fb047173a62cf7a",
   "name": "cargo-test",
   "output": Object {
-    "summary": "Tests passed",
-    "title": "Tests passed",
+    "annotations": Array [],
+    "summary": "Found no issues",
+    "title": "Found no issues",
   },
   "status": "completed",
 }

--- a/src/checks/cargo/cargo-check.ts
+++ b/src/checks/cargo/cargo-check.ts
@@ -2,6 +2,9 @@ import { filterDuplicates } from '../../common'
 import { CheckAnnotation, CheckRunCompleted } from '../checks-common'
 import {
   CargoCheckStats,
+  cargoFoundIssues,
+  cargoFoundNoIssues,
+  cargoUnexpectedOutput,
   collectAnnotations,
   collectCargoManifestParseErrors,
   filterClippyLints,
@@ -19,17 +22,7 @@ export interface CargoCheckInput {
 
 export function cargoCheckCheck({ data, sha }: CargoCheckInput, skipOtherLints = true): CheckRunCompleted {
   if (!Array.isArray(data)) {
-    return {
-      name: 'cargo-check',
-      head_sha: sha,
-      conclusion: 'skipped',
-      status: 'completed',
-      completed_at: new Date().toISOString(),
-      output: {
-        title: 'Unexpected check output',
-        summary: ''
-      }
-    }
+    return cargoUnexpectedOutput('cargo-check', sha)
   }
 
   // eslint-disable-next-line prefer-const
@@ -41,43 +34,9 @@ export function cargoCheckCheck({ data, sha }: CargoCheckInput, skipOtherLints =
   if (annotations.length > 0) {
     annotations = filterDuplicates(annotations)
 
-    const summary = `Total of ${annotations.length} ${annotations.length === 1 ? 'issue' : 'issues'}`
-    return {
-      name: 'cargo-check',
-      head_sha: sha,
-      conclusion: 'failure',
-      status: 'completed',
-      completed_at: new Date().toISOString(),
-      output: {
-        title: summary,
-        summary,
-        text: [
-          '## Results',
-          '',
-          '| Message level           | Amount |',
-          '| ----------------------- | ------ |',
-          '| Internal compiler error | ' + `${stats.ice}`.padStart(6) + ' |',
-          '| Error                   | ' + `${stats.error}`.padStart(6) + ' |',
-          '| Warning                 | ' + `${stats.warning}`.padStart(6) + ' |',
-          '| Note                    | ' + `${stats.note}`.padStart(6) + ' |',
-          '| Help                    | ' + `${stats.help}`.padStart(6) + ' |'
-        ].join('\n'),
-        annotations
-      }
-    }
+    return cargoFoundIssues('cargo-check', sha, annotations, stats)
   } else {
-    return {
-      name: 'cargo-check',
-      head_sha: sha,
-      conclusion: 'success',
-      status: 'completed',
-      completed_at: new Date().toISOString(),
-      output: {
-        title: 'Found no issues',
-        summary: 'Found no issues',
-        annotations: []
-      }
-    }
+    return cargoFoundNoIssues('cargo-check', sha)
   }
 }
 

--- a/src/checks/cargo/cargo-clippy.ts
+++ b/src/checks/cargo/cargo-clippy.ts
@@ -1,6 +1,9 @@
 import { filterDuplicates } from '../../common'
 import { CheckRunCompleted } from '../checks-common'
 import {
+  cargoFoundIssues,
+  cargoFoundNoIssues,
+  cargoUnexpectedOutput,
   collectAnnotations,
   collectCargoManifestParseErrors,
   filterNonClippyLints,
@@ -18,17 +21,7 @@ export interface CargoClippyInput {
 
 export function cargoClippyCheck({ data, sha }: CargoClippyInput, skipOtherLints = true): CheckRunCompleted {
   if (!Array.isArray(data)) {
-    return {
-      name: 'cargo-clippy',
-      head_sha: sha,
-      conclusion: 'skipped',
-      status: 'completed',
-      completed_at: new Date().toISOString(),
-      output: {
-        title: 'Unexpected clippy output',
-        summary: ''
-      }
-    }
+    return cargoUnexpectedOutput('cargo-clippy', sha)
   }
 
   // eslint-disable-next-line prefer-const
@@ -48,42 +41,8 @@ export function cargoClippyCheck({ data, sha }: CargoClippyInput, skipOtherLints
   if (annotations.length > 0) {
     annotations = filterDuplicates(annotations)
 
-    const summary = `Total of ${annotations.length} ${annotations.length === 1 ? 'issue' : 'issues'}`
-    return {
-      name: 'cargo-clippy',
-      head_sha: sha,
-      conclusion: 'failure',
-      status: 'completed',
-      completed_at: new Date().toISOString(),
-      output: {
-        title: summary,
-        summary,
-        text: [
-          '## Results',
-          '',
-          '| Message level           | Amount |',
-          '| ----------------------- | ------ |',
-          '| Internal compiler error | ' + `${stats.ice}`.padStart(6) + ' |',
-          '| Error                   | ' + `${stats.error}`.padStart(6) + ' |',
-          '| Warning                 | ' + `${stats.warning}`.padStart(6) + ' |',
-          '| Note                    | ' + `${stats.note}`.padStart(6) + ' |',
-          '| Help                    | ' + `${stats.help}`.padStart(6) + ' |'
-        ].join('\n'),
-        annotations
-      }
-    }
+    return cargoFoundIssues('cargo-clippy', sha, annotations, stats)
   } else {
-    return {
-      name: 'cargo-clippy',
-      head_sha: sha,
-      conclusion: 'success',
-      status: 'completed',
-      completed_at: new Date().toISOString(),
-      output: {
-        title: 'Found no issues',
-        summary: 'Found no issues',
-        annotations: []
-      }
-    }
+    return cargoFoundNoIssues('cargo-clippy', sha)
   }
 }

--- a/src/checks/cargo/cargo-fmt.ts
+++ b/src/checks/cargo/cargo-fmt.ts
@@ -1,6 +1,13 @@
 import { filterDuplicates, stripPrefix } from '../../common'
 import { CheckAnnotation, CheckRunCompleted } from '../checks-common'
-import { CargoCheckStats, collectAnnotations, collectCargoManifestParseErrors } from './cargo'
+import {
+  CargoCheckStats,
+  cargoFoundIssues,
+  cargoFoundNoIssues,
+  cargoUnexpectedOutput,
+  collectAnnotations,
+  collectCargoManifestParseErrors
+} from './cargo'
 import { CargoFmtFile, CargoFmtMessage, CargoFmtMismatch } from './cargo-types'
 
 export interface CargoFmtInput {
@@ -10,17 +17,7 @@ export interface CargoFmtInput {
 
 export function cargoFmtCheck({ data, sha }: CargoFmtInput): CheckRunCompleted {
   if (!Array.isArray(data)) {
-    return {
-      name: 'cargo-fmt',
-      head_sha: sha,
-      conclusion: 'skipped',
-      status: 'completed',
-      completed_at: new Date().toISOString(),
-      output: {
-        title: 'Unexpected cargo fmt output',
-        summary: ''
-      }
-    }
+    return cargoUnexpectedOutput('cargo-fmt', sha)
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars, prefer-const
@@ -32,32 +29,9 @@ export function cargoFmtCheck({ data, sha }: CargoFmtInput): CheckRunCompleted {
   if (annotations.length > 0) {
     annotations = filterDuplicates(annotations)
 
-    const summary = `Total of ${annotations.length} ${annotations.length === 1 ? 'issue' : 'issues'}`
-    return {
-      name: 'cargo-fmt',
-      head_sha: sha,
-      conclusion: 'failure',
-      status: 'completed',
-      completed_at: new Date().toISOString(),
-      output: {
-        title: summary,
-        summary,
-        annotations
-      }
-    }
+    return cargoFoundIssues('cargo-fmt', sha, annotations, stats)
   } else {
-    return {
-      name: 'cargo-fmt',
-      head_sha: sha,
-      conclusion: 'success',
-      status: 'completed',
-      completed_at: new Date().toISOString(),
-      output: {
-        title: 'Found no issues',
-        summary: 'Found no issues',
-        annotations: []
-      }
-    }
+    return cargoFoundNoIssues('cargo-fmt', sha)
   }
 }
 


### PR DESCRIPTION
Streamlined the output returned by all (Rust) checks.

[[sc-66207](https://app.shortcut.com/connectedcars/story/66207/streamline-rust-checks-implementations)]