### PR TITLE
Fixed ci flag and added cfg attribs

### DIFF
--- a/bin/checks.ts
+++ b/bin/checks.ts
@@ -67,6 +67,13 @@ async function main(argv: string[]) {
     .help()
     .parse(argv.slice(2))
 
+  // If flags are unset they are `undefined`, which results in issues
+  // when default parameters are `true`, as then the argument becomes
+  // `true` instead of `false`. To avoid issues, just set the flags
+  // to `false` if undefined.
+  flags.ci = flags.ci || false;
+  flags.hardFail = flags.hardFail || false;
+
   const [command, ...args] = commandAndArgs.map(a => a.toString())
 
   const COMMIT_SHA = process.env.COMMIT_SHA || ''

--- a/src/checks/cargo/run-cargo.ts
+++ b/src/checks/cargo/run-cargo.ts
@@ -16,10 +16,13 @@ const DEFAULT_CI_RUSTFLAGS = '-W warnings -W unused'
 export function getEnvRustFlags(ci: boolean): string {
   let rustFlags = process.env['RUSTFLAGS'] || ''
 
+  rustFlags += ' --cfg cc_build'
+
   if (ci) {
     rustFlags += ' --cfg ci_build'
+    rustFlags += ' --cfg cc_ci_build'
 
-    const ciRustFlags = process.env['CI_RUSTFLAGS'] ?? DEFAULT_CI_RUSTFLAGS
+    const ciRustFlags = process.env['CC_CI_RUSTFLAGS'] ?? process.env['CI_RUSTFLAGS'] ?? DEFAULT_CI_RUSTFLAGS
     rustFlags += ` ${ciRustFlags}`
   }
 


### PR DESCRIPTION
- Fixes issue with CLI flags, where they default to `undefined` instead of `false`. Which results in unexpected values, when passed to functions with default parameter values of `true`
- Added `cc_build` cfg attrib
- Added `cc_ci_build` cfg attrib, as an alternative to `ci_build`
- Added `CC_CI_RUSTFLAGS` env var, as an alternative to `CI_RUSTFLAGS`

Fixes: [[sc-71135](https://app.shortcut.com/connectedcars/story/71135/checks-confuses-ci-and-local-runs)]
Related: [[sc-65972](https://app.shortcut.com/connectedcars/story/65972/firmware-hal-create-lint-to-force-env-logger-and-disable-println)]
