### PR TITLE
Default to UTC tz

### DIFF
--- a/src/mysql/mysqld-utils.ts
+++ b/src/mysql/mysqld-utils.ts
@@ -279,6 +279,7 @@ export async function startMySQLd(
     ],
     {
       env: {
+        TZ: 'UTC',
         ...process.env
         // TODO Try to disable on mac
         // EVENT_NOKQUEUE: '1'


### PR DESCRIPTION
If you start up `npm run local-mysql`, and you don't set TZ, it will use system time