### PR TITLE
fix(MySQLServer): increase max_connections for all OS

### DIFF
--- a/src/mysql/__snapshots__/mysqld-utils.test.ts.snap
+++ b/src/mysql/__snapshots__/mysqld-utils.test.ts.snap
@@ -16,6 +16,9 @@ character-set-server=utf8mb4
 collation-server=utf8mb4_general_ci
 [mysqld-8.0]
 mysqlx=0
+open_files_limit=5000
+max_connections=4190
+table_open_cache=2000
 "
 `;
 
@@ -36,6 +39,9 @@ collation-server=utf8mb4_general_ci
 user=mysql
 [mysqld-8.0]
 mysqlx=0
+open_files_limit=5000
+max_connections=4190
+table_open_cache=2000
 "
 `;
 

--- a/src/mysql/mysqld-utils.ts
+++ b/src/mysql/mysqld-utils.ts
@@ -103,11 +103,6 @@ export async function getMySQLServerBaseConfig(mysqldPath: string): Promise<MySQ
     myCnf.mysqld.table_open_cache = '250'
     myCnf.mysqld.open_files_limit = '800'
     myCnf.mysqld.max_connections = '500'
-
-    // Set limits higher for 8.x
-    myCnf['mysqld-8.0'].max_connections = '2000'
-    myCnf['mysqld-8.0'].open_files_limit = '5000'
-    myCnf['mysqld-8.0'].table_open_cache = '2000'
   }
 
   return myCnf
@@ -137,7 +132,12 @@ export function generateMySQLServerConfig(
       'collation-server': 'utf8mb4_general_ci'
     },
     'mysqld-8.0': {
-      mysqlx: '0'
+      mysqlx: '0',
+      open_files_limit: '5000',
+      // The maximum effective value is the lesser of the effective value of open_files_limit - 810, and the value actually set for max_connections.
+      // https://dev.mysql.com/doc/refman/8.4/en/server-system-variables.html#sysvar_max_connections
+      max_connections: String(5000 - 810),
+      table_open_cache: '2000'
     }
   }
 


### PR DESCRIPTION
[sc-122171][skip-sc]

- Turns out that the max connections for non mac has been the default `151` which causes us to hit this the connection count error (specially on the API) when running parallel integration tests

- I tested this change on the API and i was able to run the integration tests in parallel in docker