### PR TITLE
cargo: Add nightly flag for cargo commands

### DIFF
--- a/src/checks/cargo/run-cargo-clippy.ts
+++ b/src/checks/cargo/run-cargo-clippy.ts
@@ -8,7 +8,6 @@ export async function runCargoClippy(args: string[] = [], ci = true, releaseBuil
 
   return runCargo(
     [
-      '+nightly',
       'clippy',
       releaseBuild ? '--release' : '',
       '--all-targets',

--- a/src/checks/cargo/run-cargo-clippy.ts
+++ b/src/checks/cargo/run-cargo-clippy.ts
@@ -8,6 +8,7 @@ export async function runCargoClippy(args: string[] = [], ci = true, releaseBuil
 
   return runCargo(
     [
+      '+nightly',
       'clippy',
       releaseBuild ? '--release' : '',
       '--all-targets',

--- a/src/checks/cargo/run-cargo-fmt.ts
+++ b/src/checks/cargo/run-cargo-fmt.ts
@@ -6,6 +6,8 @@ export async function runCargoFmt(args: string[] = [], ci = true): Promise<Cargo
   // While cargo and clippy emits individual json objects, rustfmt does not
 
   return runCargo<CargoFmtFile>(
+    // To get the output in JSON requires an "unstable" feature that's only available on nightly
+    // This only applies to the formatting not the code that is shipped
     ['+nightly', 'fmt', '--', '--emit=json', '--color', 'never', ...args],
     ci,
     true,

--- a/src/checks/cargo/run-cargo-test.ts
+++ b/src/checks/cargo/run-cargo-test.ts
@@ -5,8 +5,10 @@ import { runCargo } from './run-cargo'
 export async function runCargoTest(args: string[] = [], ci = true): Promise<CargoMessage[]> {
   return runCargo(
     [
+      '+nightly',
       'test',
       '--all-targets',
+      '--no-fail-fast',
       '--locked',
       '--message-format=json',
       '--',
@@ -24,8 +26,10 @@ export async function runCargoDocTest(args: string[] = [], ci = true): Promise<C
   try {
     return await runCargo(
       [
+        '+nightly',
         'test',
         '--doc',
+        '--no-fail-fast',
         '--locked',
         '--message-format=json',
         '--',

--- a/src/checks/cargo/run-cargo-test.ts
+++ b/src/checks/cargo/run-cargo-test.ts
@@ -26,6 +26,8 @@ export async function runCargoDocTest(args: string[] = [], ci = true): Promise<C
   try {
     return await runCargo(
       [
+        // Getting the output in JSON requires an "unstable" feature that's only available on nightly
+        // This only applies to the testing not the code that is shipped
         '+nightly',
         'test',
         '--doc',


### PR DESCRIPTION
The nightly option is required for the unstable options we use for the json output in Cargo, omitting it caused some tests to fail in a way that was not caught, and thus did not flag PR's with failing tests as failed in PR's