### PR TITLE
cargo: Now reports build failed even if it fails without any spans

### DIFF
--- a/src/checks/cargo/__snapshots__/cargo-check.test.ts.snap
+++ b/src/checks/cargo/__snapshots__/cargo-check.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`checks/cargo-check converts buggy cargo-check 1`] = `
 Object {
@@ -485,6 +485,21 @@ Object {
     "annotations": Array [],
     "summary": "Found no issues",
     "title": "Found no issues",
+  },
+  "status": "completed",
+}
+`;
+
+exports[`checks/cargo-check reports failure when build-finished is false but no file-level errors 1`] = `
+Object {
+  "completed_at": Any<String>,
+  "conclusion": "failure",
+  "head_sha": "11963e3cb7ecbb9247f638cc0fb047173a62cf7a",
+  "name": "cargo-check",
+  "output": Object {
+    "annotations": Array [],
+    "summary": "The build failed but produced no file-level errors. This may indicate a linker error or an error in a dependency.",
+    "title": "Build failed",
   },
   "status": "completed",
 }

--- a/src/checks/cargo/cargo-check.test.ts
+++ b/src/checks/cargo/cargo-check.test.ts
@@ -23,4 +23,14 @@ describe('checks/cargo-check', () => {
       completed_at: expect.any(String)
     })
   })
+  it('reports failure when build-finished is false but no file-level errors', () => {
+    const result = cargoCheckCheck({
+      data: [{ reason: 'build-finished', success: false } as any],
+      sha: '11963e3cb7ecbb9247f638cc0fb047173a62cf7a'
+    })
+    expect(result).toMatchSnapshot({
+      completed_at: expect.any(String)
+    })
+    expect(result.conclusion).toBe('failure')
+  })
 })

--- a/src/checks/cargo/cargo-check.ts
+++ b/src/checks/cargo/cargo-check.ts
@@ -1,6 +1,7 @@
 import { filterDuplicates } from '../../common'
 import { CheckAnnotation, CheckRunCompleted } from '../checks-common'
 import {
+  cargoBuildFailed,
   CargoCheckStats,
   cargoFoundIssues,
   cargoFoundNoIssues,
@@ -9,7 +10,8 @@ import {
   collectCargoManifestParseErrors,
   filterClippyLints,
   filterNone,
-  getPrimaryOrFirstSpan
+  getPrimaryOrFirstSpan,
+  isCargoBuildSuccessful
 } from './cargo'
 import { CargoCompilerMessage, CargoMessage } from './cargo-types'
 
@@ -35,9 +37,13 @@ export function cargoCheckCheck({ data, sha }: CargoCheckInput, skipOtherLints =
     annotations = filterDuplicates(annotations)
 
     return cargoFoundIssues('cargo-check', sha, annotations, stats)
-  } else {
-    return cargoFoundNoIssues('cargo-check', sha)
   }
+
+  if (!isCargoBuildSuccessful(data)) {
+    return cargoBuildFailed('cargo-check', sha)
+  }
+
+  return cargoFoundNoIssues('cargo-check', sha)
 }
 
 export function collectCargoCheckLints(

--- a/src/checks/cargo/cargo.ts
+++ b/src/checks/cargo/cargo.ts
@@ -116,6 +116,22 @@ export function getPrimaryOrFirstSpan(spans: DiagnosticSpan[]): DiagnosticSpan |
   return primarySpan ?? spans[0]
 }
 
+export function cargoBuildFailed(name: string, sha: string): CheckRunCompleted {
+  return {
+    name,
+    head_sha: sha,
+    conclusion: 'failure',
+    status: 'completed',
+    completed_at: new Date().toISOString(),
+    output: {
+      title: 'Build failed',
+      summary:
+        'The build failed but produced no file-level errors. This may indicate a linker error or an error in a dependency.',
+      annotations: []
+    }
+  }
+}
+
 export function cargoUnexpectedOutput(name: string, sha: string): CheckRunCompleted {
   return {
     name,


### PR DESCRIPTION
If there were no spans for the cargo-check errors like linking or other compile time errors we would before report it as a success instead of failing

This allowed us to merge broken builds to master, this fixes it and only reports the CI check as green if it's actually green